### PR TITLE
Fix the Grammar-Kit plugin doing very wrong things

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,3 +2,28 @@ plugins {
     id "io.micronaut.build.internal.docs"
     id "io.micronaut.build.internal.dependency-updates"
 }
+
+repositories {
+    // This is done because the GrammarKit plugin does something not nice at all:
+    // it transparently adds a dependency to Grammar-Kit, but that shouldn't be
+    // needed to compile sources but it breaks Javadoc generation. Worse, it does
+    // this by transparently adding Jitpack as a repository, which is completely
+    // wrong as a plugin should NEVER add repositories: it's a security problem.
+    // Therefore we limit the risks by limiting the Jitpack repo to GrammarKit.
+    maven {
+        name = "Jitpack"
+        url = "https://www.jitpack.io"
+        content {
+            includeModule("com.github.JetBrains", "Grammar-Kit")
+        }
+    }
+    // oh yes, by the way, it also adds ANOTHER repository
+    maven {
+        name = "Jetbrains Blackbox Repository"
+        url = "https://cache-redirector.jetbrains.com/intellij-dependencies"
+        content {
+            includeModule("org.jetbrains.intellij.deps.jflex", "jflex")
+        }
+    }
+
+}

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -5,19 +5,16 @@ plugins {
 
 group = 'io.micronaut.toml'
 
-task generateLexer(type: org.jetbrains.grammarkit.tasks.GenerateLexer) {
+def generateLexer = tasks.register("generateLexer", org.jetbrains.grammarkit.tasks.GenerateLexer) {
     source = 'src/main/jflex/toml.jflex'
     //skeleton = 'src/main/jflex/skeleton-toml'
     targetDir = 'build/generated/sources/jflex/io/micronaut/toml'
     targetClass = 'Lexer'
     purgeOldFiles = true
 }
+generateLexer.get() // force generation because GrammarKit is not compatible with lazy configuration
 
-sourceSets.main.java.srcDirs += ['build/generated/sources/jflex']
-
-compileJava {
-    dependsOn generateLexer
-}
+sourceSets.main.java.srcDir(generateLexer.map { it.targetDir } )
 
 dependencies {
     api mn.micronaut.json.core


### PR DESCRIPTION
This commit fixes the build so that docs generation work properly.
The Jetbrains Grammar-Kit plugin seems to accumulate mistakes, by
transparently adding repositories to the build, which is a security
risk. Unfortunately, we can't do much for the `toml` module, but
at least we can fix docs generation.