### PR TITLE
Only expose micronaut-json-core as an impl dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
+[versions]
+jetbrains-annotations = "16.0.2"
+jflex = "1.8.2"
+
 [libraries]
-micronaut-inject = { module = 'io.micronaut:micronaut-inject' }
-micronaut-json-core = { module = 'io.micronaut:micronaut-json-core' }
-micronaut-jackson-databind = { module = 'io.micronaut:micronaut-jackson-databind' }
-micronaut-test-junit5 = { module = 'io.micronaut.test:micronaut-test-junit5' }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+jflex = { module = "de.jflex:jflex", version.ref = "jflex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [libraries]
+micronaut-inject = { module = 'io.micronaut:micronaut-inject' }
 micronaut-json-core = { module = 'io.micronaut:micronaut-json-core' }
 micronaut-jackson-databind = { module = 'io.micronaut:micronaut-jackson-databind' }
 micronaut-test-junit5 = { module = 'io.micronaut.test:micronaut-test-junit5' }

--- a/jflex-plugin/build.gradle
+++ b/jflex-plugin/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'de.jflex:jflex:1.8.2'
+    implementation libs.jflex
 }
 
 

--- a/jflex-plugin/settings.gradle
+++ b/jflex-plugin/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'jflex-plugin'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,7 @@ rootProject.name = 'toml-parent'
 
 include 'toml-bom'
 include 'toml'
+
+micronautBuild {
+    importMicronautCatalog()
+}

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 dependencies {
-    api libs.micronaut.json.core
+    api libs.micronaut.inject
+    implementation libs.micronaut.json.core
     testImplementation libs.micronaut.jackson.databind
     testImplementation libs.micronaut.test.junit5
     testImplementation 'org.jetbrains:annotations:16.0.2'

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 dependencies {
-    api libs.micronaut.inject
-    implementation libs.micronaut.json.core
-    testImplementation libs.micronaut.jackson.databind
-    testImplementation libs.micronaut.test.junit5
-    testImplementation 'org.jetbrains:annotations:16.0.2'
+    api mn.micronaut.inject
+    implementation mn.micronaut.json.core
+    testImplementation mn.micronaut.jackson.databind
+    testImplementation mn.micronaut.test.junit5
+    testImplementation libs.jetbrains.annotations
 }


### PR DESCRIPTION
had to add a new dependency to micronaut inject for the `AbstractPropertySourceLoader` implementation.

Fixes #65