### PR TITLE
Fix TOML parse failure when number token hits buffer edge

### DIFF
--- a/toml/src/main/java/io/micronaut/toml/Parser.java
+++ b/toml/src/main/java/io/micronaut/toml/Parser.java
@@ -256,7 +256,12 @@ public final class Parser {
             }
         }
 
+        JsonNode v = parseInt0(buffer, start, length);
         pollExpected(TomlToken.INTEGER, nextState);
+        return v;
+    }
+
+    private JsonNode parseInt0(char[] buffer, int start, int length) throws TomlStreamReadException {
         if (length > 2) {
             char baseChar = buffer[start + 1];
             if (baseChar == 'x' || baseChar == 'o' || baseChar == 'b') {

--- a/toml/src/test/java/io/micronaut/toml/ParserTest.java
+++ b/toml/src/test/java/io/micronaut/toml/ParserTest.java
@@ -1016,4 +1016,12 @@ public class ParserTest {
                 Assertions.assertThrows(TomlStreamReadException.class, () -> toml("foo = \"\\k\"")).getOriginalMessage(),
                 Matchers.containsString("Unknown escape sequence"));
     }
+
+    @Test
+    public void longInput() throws IOException {
+        toml(
+            "foo = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n" +
+                "bar = 678\n" +
+                "baz = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"");
+    }
 }

--- a/toml/src/test/java/io/micronaut/toml/ParserTest.java
+++ b/toml/src/test/java/io/micronaut/toml/ParserTest.java
@@ -1018,10 +1018,12 @@ public class ParserTest {
     }
 
     @Test
-    public void longInput() throws IOException {
-        toml(
+    // https://github.com/micronaut-projects/micronaut-toml/pull/95
+    void longInput() {
+        Assertions.assertDoesNotThrow(() -> toml(
             "foo = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n" +
                 "bar = 678\n" +
-                "baz = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"");
+                "baz = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+        ));
     }
 }


### PR DESCRIPTION
When a number token is exactly at the end of the lexer text buffer, the parser would advance the lexer, triggering a buffer refill, before the number is parsed from the buffer. This patch moves the advance operation to come after parsing, which resolves the issue.

Also tracked as https://github.com/FasterXML/jackson-dataformats-text/pull/356

Fixes #93