### PR TITLE
Use toml-test-for-java for spec tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ micronaut = "5.0.0"
 
 jetbrains-annotations = "26.1.0"
 jflex = "1.9.1"
+toml-test-for-java = "0.2.0-2.2.0"
 
 [libraries]
 # Core
@@ -10,3 +11,4 @@ micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'mi
 
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 jflex = { module = "de.jflex:jflex", version.ref = "jflex" }
+toml-test-for-java = { module = "at.yawk.toml.test:toml-test-for-java", version.ref = "toml-test-for-java" }

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     testImplementation mn.micronaut.jackson.databind
     testImplementation mnTest.micronaut.test.junit5
     testImplementation mnTest.junit.jupiter.engine
+    testImplementation mnTest.junit.jupiter.params
+    testImplementation libs.toml.test.for.java
     testImplementation libs.jetbrains.annotations
 }
 

--- a/toml/src/main/java/io/micronaut/toml/Parser.java
+++ b/toml/src/main/java/io/micronaut/toml/Parser.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -230,16 +231,8 @@ public final class Parser {
 
     private JsonNode parseDateTime(int nextState) throws IOException {
         String originalText = lexer.yytext();
+        String text = originalText;
         TomlToken token = peek();
-        String text = normalizeDateTimeText(token, originalText);
-        if (validateDateTime) {
-            validateDateTime(token, text, originalText);
-        }
-        pollExpected(token, nextState);
-        return JsonNode.createStringNode(text);
-    }
-
-    private String normalizeDateTimeText(TomlToken token, String text) {
         // The time delimiter can be [Tt ]. java.time supports [Tt], and TOML accepts lowercase z.
         if (token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
             StringBuilder normalized = null;
@@ -257,21 +250,27 @@ public final class Parser {
                 text = normalized.toString();
             }
         }
-        return text;
-    }
 
-    private void validateDateTime(TomlToken token, String text, String originalText) throws TomlStreamReadException {
-        try {
-            switch (token) {
-                case LOCAL_DATE -> LocalDate.parse(text);
-                case LOCAL_TIME -> LocalTime.parse(text);
-                case LOCAL_DATE_TIME -> LocalDateTime.parse(text);
-                case OFFSET_DATE_TIME -> OffsetDateTime.parse(text);
-                default -> throw new AssertionError();
+        if (validateDateTime) {
+            Temporal value;
+            try {
+                if (token == TomlToken.LOCAL_DATE) {
+                    value = LocalDate.parse(text);
+                } else if (token == TomlToken.LOCAL_TIME) {
+                    value = LocalTime.parse(text);
+                } else if (token == TomlToken.LOCAL_DATE_TIME) {
+                    value = LocalDateTime.parse(text);
+                } else if (token == TomlToken.OFFSET_DATE_TIME) {
+                    value = OffsetDateTime.parse(text);
+                } else {
+                    throw new AssertionError();
+                }
+            } catch (DateTimeParseException e) {
+                throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
             }
-        } catch (DateTimeParseException e) {
-            throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
         }
+        pollExpected(token, nextState);
+        return JsonNode.createStringNode(text);
     }
 
     private JsonNode parseInt(int nextState) throws IOException {

--- a/toml/src/main/java/io/micronaut/toml/Parser.java
+++ b/toml/src/main/java/io/micronaut/toml/Parser.java
@@ -24,6 +24,12 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,21 +50,28 @@ import java.util.stream.Collectors;
 public final class Parser {
     private final TomlStreamReadException.ErrorContext errorContext;
     private final Lexer lexer;
+    private final boolean validateDateTime;
 
     private TomlToken next;
 
     private Parser(
             TomlStreamReadException.ErrorContext errorContext,
-            Reader input
+            Reader input,
+            boolean validateDateTime
     ) throws IOException {
         this.errorContext = errorContext;
         this.lexer = new Lexer(input, errorContext);
+        this.validateDateTime = validateDateTime;
         lexer.prohibitInternalBufferAllocate = false;
         this.next = lexer.yylex();
     }
 
     public static JsonNode parse(String input) throws IOException {
-        Parser parser = new Parser(new TomlStreamReadException.ErrorContext(input), new StringReader(input));
+        return parse(input, false);
+    }
+
+    static JsonNode parse(String input, boolean validateDateTime) throws IOException {
+        Parser parser = new Parser(new TomlStreamReadException.ErrorContext(input), new StringReader(input), validateDateTime);
         return parser.parse();
     }
 
@@ -217,7 +230,8 @@ public final class Parser {
     }
 
     private JsonNode parseDateTime(int nextState) throws IOException {
-        String text = lexer.yytext();
+        String originalText = lexer.yytext();
+        String text = originalText;
         TomlToken token = peek();
         // The time delimiter can be [Tt ]. java.time supports [Tt], and TOML accepts lowercase z.
         if (token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
@@ -236,31 +250,27 @@ public final class Parser {
                 text = normalized.toString();
             }
         }
-        pollExpected(token, nextState);
 
-        /*
-        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)) {
+        if (validateDateTime) {
             Temporal value;
-            if (token == TomlToken.LOCAL_DATE) {
-                value = LocalDate.parse(text);
-            } else if (token == TomlToken.LOCAL_TIME) {
-                value = LocalTime.parse(text);
-            } else {
-                if (token == TomlToken.LOCAL_DATE_TIME) {
+            try {
+                if (token == TomlToken.LOCAL_DATE) {
+                    value = LocalDate.parse(text);
+                } else if (token == TomlToken.LOCAL_TIME) {
+                    value = LocalTime.parse(text);
+                } else if (token == TomlToken.LOCAL_DATE_TIME) {
                     value = LocalDateTime.parse(text);
                 } else if (token == TomlToken.OFFSET_DATE_TIME) {
                     value = OffsetDateTime.parse(text);
                 } else {
-                    VersionUtil.throwInternal();
                     throw new AssertionError();
                 }
+            } catch (DateTimeParseException e) {
+                throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
             }
-            return factory.pojoNode(value);
-        } else {
-
-         */
+        }
+        pollExpected(token, nextState);
         return JsonNode.createStringNode(text);
-        //}
     }
 
     private JsonNode parseInt(int nextState) throws IOException {
@@ -348,10 +358,15 @@ public final class Parser {
             }
             return JsonNode.createNumberNode(v);
         }
-        if (length <= 18) {
-            long v = Long.parseLong(bufferString);
-            if (negative) {
-                v = -v;
+        if (length <= 18 || inLongRange(bufferString, negative)) {
+            long v;
+            if (length <= 18) {
+                v = Long.parseLong(bufferString);
+                if (negative) {
+                    v = -v;
+                }
+            } else {
+                v = Long.parseLong(negative ? "-" + bufferString : bufferString);
             }
             // Might still fit in int, need to check
             if ((int) v == v) {
@@ -365,6 +380,14 @@ public final class Parser {
         } catch (NumberFormatException e) {
             throw errorContext.atPosition(lexer).invalidNumber(e);
         }
+    }
+
+    private static boolean inLongRange(String bufferString, boolean negative) {
+        if (bufferString.length() != 19) {
+            return false;
+        }
+        String limit = negative ? "9223372036854775808" : "9223372036854775807";
+        return bufferString.compareTo(limit) <= 0;
     }
 
     private JsonNode parseFloat(int nextState) throws IOException {

--- a/toml/src/main/java/io/micronaut/toml/Parser.java
+++ b/toml/src/main/java/io/micronaut/toml/Parser.java
@@ -29,7 +29,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -231,8 +230,16 @@ public final class Parser {
 
     private JsonNode parseDateTime(int nextState) throws IOException {
         String originalText = lexer.yytext();
-        String text = originalText;
         TomlToken token = peek();
+        String text = normalizeDateTimeText(token, originalText);
+        if (validateDateTime) {
+            validateDateTime(token, text, originalText);
+        }
+        pollExpected(token, nextState);
+        return JsonNode.createStringNode(text);
+    }
+
+    private String normalizeDateTimeText(TomlToken token, String text) {
         // The time delimiter can be [Tt ]. java.time supports [Tt], and TOML accepts lowercase z.
         if (token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
             StringBuilder normalized = null;
@@ -250,27 +257,21 @@ public final class Parser {
                 text = normalized.toString();
             }
         }
+        return text;
+    }
 
-        if (validateDateTime) {
-            Temporal value;
-            try {
-                if (token == TomlToken.LOCAL_DATE) {
-                    value = LocalDate.parse(text);
-                } else if (token == TomlToken.LOCAL_TIME) {
-                    value = LocalTime.parse(text);
-                } else if (token == TomlToken.LOCAL_DATE_TIME) {
-                    value = LocalDateTime.parse(text);
-                } else if (token == TomlToken.OFFSET_DATE_TIME) {
-                    value = OffsetDateTime.parse(text);
-                } else {
-                    throw new AssertionError();
-                }
-            } catch (DateTimeParseException e) {
-                throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
+    private void validateDateTime(TomlToken token, String text, String originalText) throws TomlStreamReadException {
+        try {
+            switch (token) {
+                case LOCAL_DATE -> LocalDate.parse(text);
+                case LOCAL_TIME -> LocalTime.parse(text);
+                case LOCAL_DATE_TIME -> LocalDateTime.parse(text);
+                case OFFSET_DATE_TIME -> OffsetDateTime.parse(text);
+                default -> throw new AssertionError();
             }
+        } catch (DateTimeParseException e) {
+            throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
         }
-        pollExpected(token, nextState);
-        return JsonNode.createStringNode(text);
     }
 
     private JsonNode parseInt(int nextState) throws IOException {

--- a/toml/src/main/java/io/micronaut/toml/TomlStreamReadException.java
+++ b/toml/src/main/java/io/micronaut/toml/TomlStreamReadException.java
@@ -18,6 +18,7 @@ package io.micronaut.toml;
 import io.micronaut.core.annotation.Internal;
 
 import java.io.IOException;
+import java.time.format.DateTimeParseException;
 
 /**
  * TOML Stream Read Exception.
@@ -137,6 +138,14 @@ public final class TomlStreamReadException
 
             TomlStreamReadException invalidNumber(NumberFormatException cause) {
                 return new TomlStreamReadException("Invalid number representation", location, cause);
+            }
+
+            TomlStreamReadException invalidDateTime(DateTimeParseException cause, String value) {
+                return new TomlStreamReadException(
+                        "Invalid date/time value ('" + value + "'), problem: " + cause.getMessage(),
+                        location,
+                        cause
+                );
             }
         }
     }

--- a/toml/src/test/java/io/micronaut/toml/ParserTest.java
+++ b/toml/src/test/java/io/micronaut/toml/ParserTest.java
@@ -460,7 +460,7 @@ public class ParserTest {
     }
 
     @Test
-    public void dateTimeValidationIsOptional() throws IOException {
+    void dateTimeValidationIsOptional() throws IOException {
         Assertions.assertEquals(
                 json("{\"date\": \"2024-02-30\"}"),
                 toml("date = 2024-02-30")

--- a/toml/src/test/java/io/micronaut/toml/ParserTest.java
+++ b/toml/src/test/java/io/micronaut/toml/ParserTest.java
@@ -460,6 +460,20 @@ public class ParserTest {
     }
 
     @Test
+    public void dateTimeValidationIsOptional() throws IOException {
+        Assertions.assertEquals(
+                json("{\"date\": \"2024-02-30\"}"),
+                toml("date = 2024-02-30")
+        );
+
+        TomlStreamReadException thrown = Assertions.assertThrows(
+                TomlStreamReadException.class,
+                () -> Parser.parse("date = 2024-02-30", true)
+        );
+        MatcherAssert.assertThat(thrown.getOriginalMessage(), Matchers.containsString("Invalid date/time value"));
+    }
+
+    @Test
     public void array() throws IOException {
         Assertions.assertEquals(
                 json("{\"integers\": [1,2,3], \"colors\": [\"red\",\"yellow\",\"green\"], \"nested_arrays_of_ints\": [ [ 1, 2 ], [3, 4, 5] ], \"nested_mixed_array\": [ [ 1, 2 ], [\"a\", \"b\", \"c\"] ], \"string_array\": [ \"all\", \"strings\", \"are the same\", \"type\" ],\n" +

--- a/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
+++ b/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
@@ -1,0 +1,148 @@
+package io.micronaut.toml;
+
+import at.yawk.toml.test.TomlExpectedDocumentValidator;
+import at.yawk.toml.test.TomlTestCase;
+import io.micronaut.jackson.core.tree.JsonNodeTreeCodec;
+import io.micronaut.json.JsonStreamConfig;
+import io.micronaut.json.tree.JsonNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class TomlTestSuiteTest {
+    private static final TomlExpectedDocumentValidator VALIDATOR = new MicronautJsonNodeValidator();
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("at.yawk.toml.test.TomlTestSuite#validToml100")
+    void validToml100(TomlTestCase testCase) throws IOException {
+        String toml = tomlString(testCase);
+        JsonNode actual = Parser.parse(toml, true);
+
+        VALIDATOR.validate(testCase, unwrapObject(actual));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("at.yawk.toml.test.TomlTestSuite#invalidToml100")
+    void invalidToml100(TomlTestCase testCase) {
+        Assertions.assertThrows(IOException.class, () -> Parser.parse(tomlString(testCase), true), testCase::id);
+    }
+
+    private static String tomlString(TomlTestCase testCase) throws CharacterCodingException {
+        return StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(testCase.tomlBytes()))
+            .toString();
+    }
+
+    private static Map<String, ?> unwrapObject(JsonNode node) {
+        Assertions.assertTrue(node.isObject(), "TOML document root must be an object");
+        Map<String, Object> unwrapped = new LinkedHashMap<>();
+        node.entries().forEach(entry -> unwrapped.put(entry.getKey(), unwrap(entry.getValue())));
+        return unwrapped;
+    }
+
+    private static Object unwrap(JsonNode node) {
+        if (node.isNumber()) {
+            return node.getNumberValue();
+        }
+        if (node.isNull()) {
+            return null;
+        }
+        if (node.isBoolean()) {
+            return node.getBooleanValue();
+        }
+        if (node.isArray()) {
+            List<Object> unwrapped = new ArrayList<>();
+            node.values().forEach(value -> unwrapped.add(unwrap(value)));
+            return unwrapped;
+        }
+        if (node.isObject()) {
+            return unwrapObject(node);
+        }
+        return node.getStringValue();
+    }
+
+    private static final class MicronautJsonNodeValidator extends TomlExpectedDocumentValidator {
+        @Override
+        protected Map<String, ?> parseExpectedJson(String expectedJson) {
+            try {
+                return unwrapObject(JsonNodeTreeCodec.getInstance()
+                    .withConfig(JsonStreamConfig.DEFAULT.withUseBigDecimalForFloats(true))
+                    .readTree(JsonFactory.builder()
+                        .configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS, true)
+                        .build()
+                        .createParser(expectedJson)));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Invalid expected JSON", e);
+            }
+        }
+
+        @Override
+        protected void validateOffsetDateTime(String path, String expected, Object actual) {
+            if (actual instanceof String actualString) {
+                Assertions.assertEquals(OffsetDateTime.parse(normalizeDateTime(expected)), OffsetDateTime.parse(actualString), path);
+            } else {
+                super.validateOffsetDateTime(path, expected, actual);
+            }
+        }
+
+        @Override
+        protected void validateLocalDateTime(String path, String expected, Object actual) {
+            if (actual instanceof String actualString) {
+                Assertions.assertEquals(LocalDateTime.parse(normalizeDateTime(expected)), LocalDateTime.parse(actualString), path);
+            } else {
+                super.validateLocalDateTime(path, expected, actual);
+            }
+        }
+
+        @Override
+        protected void validateLocalDate(String path, String expected, Object actual) {
+            if (actual instanceof String actualString) {
+                Assertions.assertEquals(LocalDate.parse(expected), LocalDate.parse(actualString), path);
+            } else {
+                super.validateLocalDate(path, expected, actual);
+            }
+        }
+
+        @Override
+        protected void validateLocalTime(String path, String expected, Object actual) {
+            if (actual instanceof String actualString) {
+                Assertions.assertEquals(LocalTime.parse(expected), LocalTime.parse(actualString), path);
+            } else {
+                super.validateLocalTime(path, expected, actual);
+            }
+        }
+
+        private static String normalizeDateTime(String value) {
+            StringBuilder normalized = null;
+            if (value.length() > 10 && value.charAt(10) != 'T') {
+                normalized = new StringBuilder(value);
+                normalized.setCharAt(10, 'T');
+            }
+            if (value.endsWith("z")) {
+                if (normalized == null) {
+                    normalized = new StringBuilder(value);
+                }
+                normalized.setCharAt(value.length() - 1, 'Z');
+            }
+            return normalized == null ? value : normalized.toString();
+        }
+    }
+}

--- a/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
+++ b/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
@@ -2,14 +2,10 @@ package io.micronaut.toml;
 
 import at.yawk.toml.test.TomlExpectedDocumentValidator;
 import at.yawk.toml.test.TomlTestCase;
-import io.micronaut.jackson.core.tree.JsonNodeTreeCodec;
-import io.micronaut.json.JsonStreamConfig;
 import io.micronaut.json.tree.JsonNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import tools.jackson.core.json.JsonFactory;
-import tools.jackson.core.json.JsonReadFeature;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -40,7 +36,11 @@ class TomlTestSuiteTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("at.yawk.toml.test.TomlTestSuite#invalidToml100")
     void invalidToml100(TomlTestCase testCase) {
-        Assertions.assertThrows(IOException.class, () -> Parser.parse(tomlString(testCase), true), testCase::id);
+        Assertions.assertThrows(IOException.class, () -> parseInvalidToml(testCase), testCase::id);
+    }
+
+    private static void parseInvalidToml(TomlTestCase testCase) throws IOException {
+        Parser.parse(tomlString(testCase), true);
     }
 
     private static String tomlString(TomlTestCase testCase) throws CharacterCodingException {
@@ -83,12 +83,7 @@ class TomlTestSuiteTest {
         @Override
         protected Map<String, ?> parseExpectedJson(String expectedJson) {
             try {
-                return unwrapObject(JsonNodeTreeCodec.getInstance()
-                    .withConfig(JsonStreamConfig.DEFAULT.withUseBigDecimalForFloats(true))
-                    .readTree(JsonFactory.builder()
-                        .configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS, true)
-                        .build()
-                        .createParser(expectedJson)));
+                return unwrapObject(ParserTest.json(expectedJson));
             } catch (IOException e) {
                 throw new IllegalArgumentException("Invalid expected JSON", e);
             }


### PR DESCRIPTION
## Summary
- add the published `toml-test-for-java` harness through the Gradle version catalog
- add TOML 1.0 valid/invalid corpus coverage using `TomlExpectedDocumentValidator`
- make date/time validation opt-in for the corpus tests while preserving default parser string-mode behavior
- align int64 minimum parsing and date/time validation flow with upstream Jackson TOML behavior

## Verification
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility -Dpts.enabled=false --no-daemon`
- JUnit XML: `TomlPropertySourceLoaderSpec` 1/0, `ParserTest` 90/0, `TomlTestSuiteTest` 679/0

Resolves #331