### PR TITLE
Support TOML 1.1 parsing

### DIFF
--- a/toml/src/main/java/io/micronaut/toml/Parser.java
+++ b/toml/src/main/java/io/micronaut/toml/Parser.java
@@ -234,17 +234,39 @@ public final class Parser {
         String text = originalText;
         TomlToken token = peek();
         // The time delimiter can be [Tt ]. java.time supports [Tt], and TOML accepts lowercase z.
-        if (token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
+        if (token == TomlToken.LOCAL_TIME || token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
             StringBuilder normalized = null;
-            if (text.charAt(10) == ' ') {
+            int timeStart = token == TomlToken.LOCAL_TIME ? 0 : 11;
+            int timeEnd = text.length();
+            if (token == TomlToken.OFFSET_DATE_TIME) {
+                char last = text.charAt(text.length() - 1);
+                if (last == 'z' || last == 'Z') {
+                    timeEnd--;
+                } else {
+                    int plus = text.indexOf('+', timeStart);
+                    int minus = text.indexOf('-', timeStart);
+                    int offsetStart = plus < 0 ? minus : (minus < 0 ? plus : Math.min(plus, minus));
+                    if (offsetStart >= 0) {
+                        timeEnd = offsetStart;
+                    }
+                }
+            }
+            int secondsColon = text.indexOf(':', timeStart + 3);
+            if (secondsColon < 0 || secondsColon >= timeEnd) {
                 normalized = new StringBuilder(text);
+                normalized.insert(timeEnd, ":00");
+            }
+            if (token != TomlToken.LOCAL_TIME && text.charAt(10) == ' ') {
+                if (normalized == null) {
+                    normalized = new StringBuilder(text);
+                }
                 normalized.setCharAt(10, 'T');
             }
             if (token == TomlToken.OFFSET_DATE_TIME && text.charAt(text.length() - 1) == 'z') {
                 if (normalized == null) {
                     normalized = new StringBuilder(text);
                 }
-                normalized.setCharAt(text.length() - 1, 'Z');
+                normalized.setCharAt(normalized.length() - 1, 'Z');
             }
             if (normalized != null) {
                 text = normalized.toString();
@@ -415,13 +437,7 @@ public final class Parser {
         while (true) {
             TomlToken token = peek();
             if (token == TomlToken.INLINE_TABLE_CLOSE) {
-                if (node.isEmpty()) {
-                    break;
-                } else {
-                    // "A terminating comma (also called trailing comma) is not permitted after the last key/value pair
-                    // in an inline table."
-                    throw errorContext.atPosition(lexer).generic("Trailing comma not permitted for inline tables");
-                }
+                break;
             }
             parseKeyVal(node, Lexer.EXPECT_TABLE_SEP);
             TomlToken sepToken = peek();

--- a/toml/src/main/jflex/io/micronaut/toml/toml.jflex
+++ b/toml/src/main/jflex/io/micronaut/toml/toml.jflex
@@ -100,6 +100,12 @@ this.zzBuffer = new char[256];
       }
   }
 
+  private void appendUnicodeEscapeByte() throws TomlStreamReadException {
+      int value = (Character.digit(yycharat(2), 16) << 4) |
+                   Character.digit(yycharat(3), 16);
+      appendUnicodeScalar(value);
+  }
+
   private void appendUnicodeEscapeShort() throws TomlStreamReadException {
       int value = (Character.digit(yycharat(2), 16) << 12) |
                    (Character.digit(yycharat(3), 16) << 8) |
@@ -172,6 +178,7 @@ QuotationMark = "\""
 // exclude control chars (tab is allowed, " and \)
 //BasicUnescaped = [^\u0000-\u0008\u0009-\u001f\u007f\\\"]
 //Escaped = "\\" ([\"\\bfnrt]|"u" {HexDig} {HexDig} {HexDig} {HexDig} ({HexDig} {HexDig} {HexDig} {HexDig})?)
+UnicodeEscapeByte = "\\x" {HexDig} {HexDig}
 UnicodeEscapeShort = "\\u" {HexDig} {HexDig} {HexDig} {HexDig}
 UnicodeEscapeLong = "\\U" {HexDig} {HexDig} {HexDig} {HexDig} {HexDig} {HexDig} {HexDig} {HexDig}
 
@@ -213,7 +220,7 @@ TimeSecond = [0-9][0-9]
 TimeSecfrac = "." [0-9]+
 TimeNumoffset = [+-] {TimeHour} ":" {TimeMinute}
 TimeOffset = [Zz] | {TimeNumoffset}
-PartialTime = {TimeHour} ":" {TimeMinute} ":" {TimeSecond} {TimeSecfrac}?
+PartialTime = {TimeHour} ":" {TimeMinute} (":" {TimeSecond} {TimeSecfrac}?)?
 FullDate = {DateFullyear} "-" {DateMonth} "-" {DateMday}
 FullTime = {PartialTime} {TimeOffset}
 
@@ -319,7 +326,7 @@ HexDig = [0-9A-Fa-f]
           startString();
       }
     {KeyValSep} {return TomlToken.KEY_VAL_SEP;}
-    {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
+    {WsCommentNewlineNonEmpty}* {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
     {StdTableClose} {return TomlToken.STD_TABLE_CLOSE;}
     {ArrayTableClose} {return TomlToken.ARRAY_TABLE_CLOSE;}
 }
@@ -376,7 +383,7 @@ HexDig = [0-9A-Fa-f]
 
     // inline array / table
     {ArrayOpen} {WsCommentNewlineNonEmpty}* {return TomlToken.ARRAY_OPEN;}
-    {InlineTableOpen} {return TomlToken.INLINE_TABLE_OPEN;}
+    {InlineTableOpen} {WsCommentNewlineNonEmpty}* {return TomlToken.INLINE_TABLE_OPEN;}
 
     // array end just after comma
     {WsCommentNewlineNonEmpty}* {ArrayClose} {return TomlToken.ARRAY_CLOSE;}
@@ -394,8 +401,8 @@ HexDig = [0-9A-Fa-f]
     // inline-table = inline-table-open [ inline-table-keyvals ] inline-table-close
     // inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
 
-    {Ws} {Comma} {Ws} {return TomlToken.COMMA;}
-    {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
+    {WsCommentNewlineNonEmpty}* {Comma} {WsCommentNewlineNonEmpty}* {return TomlToken.COMMA;}
+    {WsCommentNewlineNonEmpty}* {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
 }
 
 <BASIC_STRING> {
@@ -439,6 +446,8 @@ HexDig = [0-9A-Fa-f]
     \\n { textBuffer.append('\n'); }
     \\r { textBuffer.append('\r'); }
     \\t { textBuffer.append('\t'); }
+    \\e { textBuffer.append('\u001B'); }
+    {UnicodeEscapeByte} { appendUnicodeEscapeByte(); }
     {UnicodeEscapeShort} { appendUnicodeEscapeShort(); }
     {UnicodeEscapeLong} { appendUnicodeEscapeLong(); }
     \\ { throw errorContext.atPosition(this).generic("Unknown escape sequence"); }

--- a/toml/src/test/java/io/micronaut/toml/ParserTest.java
+++ b/toml/src/test/java/io/micronaut/toml/ParserTest.java
@@ -78,6 +78,40 @@ public class ParserTest {
     }
 
     @Test
+    public void toml11BasicStringEscapes() throws IOException {
+        Assertions.assertEquals(
+                json("{\"esc\": \"\\u001B[\", \"hex\": \"a\\u0000\"}"),
+                toml("esc = \"\\e[\"\n" +
+                        "hex = \"\\x61\\x00\""));
+    }
+
+    @Test
+    public void toml11OptionalSeconds() throws IOException {
+        Assertions.assertEquals(
+                json("{\"localTime\": \"14:15:00\", \"localDateTime\": \"2010-02-03T14:15:00\", " +
+                        "\"offsetDateTimeZ\": \"2010-02-03T14:15:00Z\", " +
+                        "\"offsetDateTimePlus\": \"2010-02-03T14:15:00+02:30\", " +
+                        "\"offsetDateTimeMinus\": \"2010-02-03T14:15:00-02:30\"}"),
+                toml("localTime = 14:15\n" +
+                        "localDateTime = 2010-02-03 14:15\n" +
+                        "offsetDateTimeZ = 2010-02-03 14:15Z\n" +
+                        "offsetDateTimePlus = 2010-02-03 14:15+02:30\n" +
+                        "offsetDateTimeMinus = 2010-02-03 14:15-02:30"));
+    }
+
+    @Test
+    public void toml11InlineTableNewlinesAndTrailingComma() throws IOException {
+        Assertions.assertEquals(
+                json("{\"tbl\": {\"key\": \"a string\", \"nested\": {\"key\": 1}}}"),
+                toml("tbl = {\n" +
+                        "    key = \"a string\",\n" +
+                        "    nested = {\n" +
+                        "        key = 1,\n" +
+                        "    },\n" +
+                        "}"));
+    }
+
+    @Test
     public void quotedKeys() throws IOException {
         Assertions.assertEquals(
                 json("{\"127.0.0.1\": \"value\", \"character encoding\": \"value\", \"ʎǝʞ\": \"value\", \"key2\": \"value\", \"quoted \\\"value\\\"\": \"value\"}"),
@@ -887,9 +921,10 @@ public class ParserTest {
 
     @Test
     public void inlineTableTrailingComma() throws IOException {
-        MatcherAssert.assertThat(
-                Assertions.assertThrows(TomlStreamReadException.class, () -> toml("foo = {bar = 'baz',}")).getOriginalMessage(),
-                Matchers.containsString("Trailing comma not permitted for inline tables"));
+        Assertions.assertEquals(
+                json("{\"foo\": {\"bar\": \"baz\"}}"),
+                toml("foo = {bar = 'baz',}")
+        );
     }
 
     @Test
@@ -902,10 +937,11 @@ public class ParserTest {
 
     @Test
     public void inlineTableNl() throws IOException {
-        MatcherAssert.assertThat(
-                Assertions.assertThrows(TomlStreamReadException.class, () -> toml("foo = {bar = 'baz',\n" +
-                        "a = 'b'}")).getOriginalMessage(),
-                Matchers.containsString("Newline not permitted here"));
+        Assertions.assertEquals(
+                json("{\"foo\": {\"bar\": \"baz\", \"a\": \"b\"}}"),
+                toml("foo = {bar = 'baz',\n" +
+                        "a = 'b'}")
+        );
     }
 
     @Test

--- a/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
+++ b/toml/src/test/java/io/micronaut/toml/TomlTestSuiteTest.java
@@ -25,8 +25,8 @@ class TomlTestSuiteTest {
     private static final TomlExpectedDocumentValidator VALIDATOR = new MicronautJsonNodeValidator();
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("at.yawk.toml.test.TomlTestSuite#validToml100")
-    void validToml100(TomlTestCase testCase) throws IOException {
+    @MethodSource("at.yawk.toml.test.TomlTestSuite#validToml110")
+    void validToml110(TomlTestCase testCase) throws IOException {
         String toml = tomlString(testCase);
         JsonNode actual = Parser.parse(toml, true);
 
@@ -34,8 +34,8 @@ class TomlTestSuiteTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("at.yawk.toml.test.TomlTestSuite#invalidToml100")
-    void invalidToml100(TomlTestCase testCase) {
+    @MethodSource("at.yawk.toml.test.TomlTestSuite#invalidToml110")
+    void invalidToml110(TomlTestCase testCase) {
         Assertions.assertThrows(IOException.class, () -> parseInvalidToml(testCase), testCase::id);
     }
 


### PR DESCRIPTION
## Summary
- add TOML 1.1 string escape support for `\e` and `\xNN`
- allow optional seconds in local/offset time parsing and normalize parsed output
- allow TOML 1.1 inline-table newlines/comments and trailing commas
- switch TOML compliance coverage to the 1.1 corpus

## Verification
- `./gradlew :micronaut-toml:test --tests io.micronaut.toml.ParserTest --tests io.micronaut.toml.TomlTestSuiteTest -q`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility`

Resolves #335