### PR TITLE
Serde Toml docs

### DIFF
--- a/doc-examples/example-toml-java/build.gradle
+++ b/doc-examples/example-toml-java/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "java-library"
+}
+
+dependencies {
+    annotationProcessor mn.micronaut.inject.java
+    annotationProcessor libs.micronaut.serde.processor
+
+    implementation projects.micronautToml
+    implementation projects.micronautTomlSerde
+
+    runtimeOnly mnLogging.logback.classic
+
+    testAnnotationProcessor mn.micronaut.inject.java
+
+    testImplementation mnTest.micronaut.test.junit5
+    testRuntimeOnly mnTest.junit.jupiter.engine
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/doc-examples/example-toml-java/src/main/java/example/Book.java
+++ b/doc-examples/example-toml-java/src/main/java/example/Book.java
@@ -1,0 +1,22 @@
+package example;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class Book {
+    private final String title;
+    private final int pages;
+
+    public Book(String title, int pages) {
+        this.title = title;
+        this.pages = pages;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+}

--- a/doc-examples/example-toml-java/src/main/java/example/TomlService.java
+++ b/doc-examples/example-toml-java/src/main/java/example/TomlService.java
@@ -1,0 +1,19 @@
+package example;
+
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.toml.TomlObjectMapper;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+final class TomlService {
+    private final ObjectMapper tomlMapper;
+
+    TomlService(@Named(TomlObjectMapper.NAME) ObjectMapper tomlMapper) {
+        this.tomlMapper = tomlMapper;
+    }
+
+    ObjectMapper tomlMapper() {
+        return tomlMapper;
+    }
+}

--- a/doc-examples/example-toml-java/src/main/java/example/package-info.java
+++ b/doc-examples/example-toml-java/src/main/java/example/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * TOML examples used by the Micronaut TOML guide.
+ */
+@NullMarked
+package example;
+
+import org.jspecify.annotations.NullMarked;

--- a/doc-examples/example-toml-java/src/test/java/example/BookTest.java
+++ b/doc-examples/example-toml-java/src/test/java/example/BookTest.java
@@ -1,0 +1,24 @@
+package example;
+
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.toml.TomlObjectMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+public class BookTest {
+
+    @Test
+    void testWriteReadBook(@Named(TomlObjectMapper.NAME) ObjectMapper tomlMapper) throws IOException {
+        String result = tomlMapper.writeValueAsString(new Book("The Stand", 50));
+
+        Book book = tomlMapper.readValue(result, Book.class);
+        assertEquals("The Stand", book.getTitle());
+        assertEquals(50, book.getPages());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include 'toml-bom'
 include 'toml'
 include 'toml-serde'
 include 'toml-serde-tck'
+include 'doc-examples:example-toml-java'
 include 'test-suite-toml-jackson-databind'
 
 micronautBuild {

--- a/src/main/docs/guide/quickStart/tomlQuick.adoc
+++ b/src/main/docs/guide/quickStart/tomlQuick.adoc
@@ -1,0 +1,113 @@
+[[toml-serde]]
+The `toml-serde` module integrates https://toml.io/en/[TOML] with Micronaut Serialization.
+Use this module when you need to read or write TOML with api:serde.ObjectMapper[].
+
+Add the following artifact to the `dependencies` block:
+
+dependency:toml-serde[groupId="io.micronaut.toml",scope="implementation"]
+
+The TOML module contributes a named mapper bean.
+Inject `@Named(TomlObjectMapper.NAME)` when an application has more than one api:serde.ObjectMapper[]:
+
+snippet::example.TomlService[project-base="doc-examples/example-toml", source="main"]
+
+With the correct dependencies in place you can now define an object to be serialized:
+
+snippet::example.Book[project-base="doc-examples/example-toml", source="main"]
+
+The type is annotated with ann:serde.annotation.Serdeable[] to enable serialization and deserialization.
+The constructor is used to create the deserialized bean, and bean properties are written as TOML keys.
+
+Once you have a type that can be serialized and deserialized you can use the TOML api:serde.ObjectMapper[] bean to do so:
+
+snippet::example.BookTest[project-base="doc-examples/example-toml"]
+
+The mapper also supports the generic `Argument<T>` overloads when the target type has generic parameters.
+
+== TOML Mapper Configuration
+
+TOML-specific mapper configuration is under `micronaut.serde.toml`.
+The available settings are:
+
+* `micronaut.serde.toml.write-features.write-layout` - controls serialized TOML output layout. Supported values are `table` and `inline`; the default is `table`.
+* `micronaut.serde.toml.read-constraints.max-document-size` - maximum TOML document size in bytes before parsing. The default is `1048576` bytes, and a non-positive value disables the limit.
+* `micronaut.serde.toml.read-constraints.max-string-length` - maximum string value length. The default has no TOML-specific limit.
+* `micronaut.serde.toml.read-constraints.max-number-length` - maximum number token length. The default uses the parser default.
+
+[configuration]
+----
+micronaut:
+  serde:
+    toml:
+      write-features:
+        write-layout: table
+      read-constraints:
+        max-document-size: 1048576
+        max-string-length: 65536
+        max-number-length: 1000
+----
+
+The general Micronaut Serialization settings under `micronaut.serde.*` still apply to the TOML mapper where relevant.
+For example, serialization inclusion settings affect empty values, while TOML text still omits `null` properties because TOML has no `null` literal.
+
+== TOML Output Layout
+
+The TOML mapper writes nested object graphs in table layout by default.
+For example, a bean with an `author` property is written with a TOML table header:
+
+[source,toml]
+----
+title = 'Micronaut in Action'
+pages = 320
+
+[author]
+name = 'Ada'
+----
+
+Arrays of objects are written as arrays of tables:
+
+[source,toml]
+----
+[[products]]
+name = 'Hammer'
+sku = 738594937
+
+[[products]]
+name = 'Nail'
+sku = 284758393
+----
+
+Configure the mapper to write nested objects with TOML inline tables instead:
+
+[configuration]
+----
+micronaut:
+  serde:
+    toml:
+      write-features:
+        write-layout: inline
+----
+
+With inline layout, the same nested values are written as inline table values:
+
+[source,toml]
+----
+title = 'Micronaut in Action'
+pages = 320
+author = {name = 'Ada'}
+----
+
+An array of objects is written as a single inline array value:
+
+[source,toml]
+----
+products = [{name = 'Hammer', sku = 738594937}, {name = 'Nail', sku = 284758393}]
+----
+
+Set `micronaut.serde.toml.write-features.write-layout` to `table` to select the default table output explicitly.
+The write layout only controls serialization output.
+The mapper can read valid TOML that uses standard table headers, arrays of tables, inline tables, or inline arrays.
+
+TOML has no `null` literal.
+When writing TOML text, null object properties are omitted.
+The TOML mapper also expects the serialized root value to be an object, because a complete TOML document is a set of key/value pairs and tables.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,5 +3,6 @@ introduction:
 releaseHistory: Release History
 quickStart:
   title: Quick Start
+  tomlQuick: TOML Serde
 repository: Repository
 


### PR DESCRIPTION
This Pr adds documentation to **toml-serde**, because of serde-toml mapper can't come by gradle dependency 
and provide examples within micronaut-serialization doc-examples with hand of **snippet reference**.

The examples no more in [serde](https://github.com/micronaut-projects/micronaut-serialization/pull/1349) they are Here, we only reference them. 

please find attached image : micronaut-serialization docs

<img width="1165" height="240" alt="image" src="https://github.com/user-attachments/assets/22ebfb0e-7394-4787-baf8-aa42e1ffb7fe" />
